### PR TITLE
JDP250201-18: dodano zestaw testów encji Group i interfejs ProductRepository + drobne zmiany w Group i Product + refactoring Cart

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/controller/UserController.java
+++ b/src/main/java/com/kodilla/ecommercee/controller/UserController.java
@@ -1,6 +1,6 @@
-package com.kodilla.ecommercee.user.controller;
+package com.kodilla.ecommercee.controller;
 
-import com.kodilla.ecommercee.user.domain.UserDto;
+import com.kodilla.ecommercee.domain.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/kodilla/ecommercee/domain/Cart.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Cart.java
@@ -4,47 +4,34 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity(name = "CARTS")
+@Entity
+@Table(name = "CARTS")
 public class Cart {
 
-    private int id;
-    private User users;
-    private List<Product> products = new ArrayList<>();
-
     @Id
-    @GeneratedValue
-    @Column(name = "CART_ID")
-    public int getId() {
-        return id;
-    }
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CART_ID", nullable = false)
+    private Long id;
 
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    @JoinColumn(name = "USER_ID")
-    public User getUsers() {
-        return users;
-    }
+// !!! Czeka na implementację encji User !!!
+//    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+//    @JoinColumn(name = "USER_ID", nullable = false)
+//    private User users;
 
-    @ManyToMany(cascade = CascadeType.ALL)
-    public List<Product> getProducts() {
-        return products;
-    }
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "CART_PRODUCT",
+            joinColumns = @JoinColumn(name = "CART_ID"),
+            inverseJoinColumns = @JoinColumn(name = "PRODUCT_ID")
+    )
+    private List<Product> products;
 
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public void setUsers(User users) {
-        this.users = users;
-    }
-
-    public void setProducts(List<Product> products) {
-        this.products = products;
-    }
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -16,13 +16,14 @@ public class Group {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "GRUOP_ID", unique = true)
+    @Column(name = "GROUP_ID", unique = true)
     private Long id;
 
-    @Column(name = "GRUOP_NAME", nullable = false, length = 100)
+    @Column(name = "GROUP_NAME", nullable = false, length = 100)
     private String name;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JsonIgnore
     private List<Product> products;
+
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/Product.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Product.java
@@ -1,13 +1,12 @@
 package com.kodilla.ecommercee.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -16,7 +15,8 @@ public class Product {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    @Column(name = "PRODUCT_ID")
+    private Long id;
 
     @Column(name = "NAME", nullable = false)
     private String name;
@@ -27,8 +27,8 @@ public class Product {
     @Column(name = "PRICE", nullable = false)
     private BigDecimal price;
 
-//    !!! Do czasu dodania encji Group relacja musi być zakomentowana żeby projekt się budował. !!!
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "GROUP_ID", nullable = false)
     private Group group;
+
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/UserDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/UserDto.java
@@ -1,4 +1,4 @@
-package com.kodilla.ecommercee.user.domain;
+package com.kodilla.ecommercee.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/kodilla/ecommercee/repository/ProductRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/ProductRepository.java
@@ -1,10 +1,9 @@
 package com.kodilla.ecommercee.repository;
 
-
-import com.kodilla.ecommercee.domain.Group;
+import com.kodilla.ecommercee.domain.Product;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GroupRepository extends CrudRepository<Group, Long> {
+public interface ProductRepository extends CrudRepository<Product, Long> {
 }

--- a/src/test/java/com/kodilla/ecommercee/domain/GroupTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/GroupTestSuite.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -128,7 +129,7 @@ public class GroupTestSuite {
             // Sprawdzam czy produkty zostały przypisane do grupy
             Group retrievedGroup = foundGroup.get();
             System.out.println("Group ID: " + retrievedGroup.getId());
-            System.out.println("Products in group: " + retrievedGroup.getProducts());// Debugowanie
+            System.out.println("Products in group: " + retrievedGroup.getProducts());
             System.out.println("Retrieved Products: " + retrievedGroup.getProducts().size());
             retrievedGroup.getProducts().forEach(p -> System.out.println("Product: " + p.getName()));
 
@@ -138,5 +139,30 @@ public class GroupTestSuite {
         Assertions.assertFalse(retrievedGroup.getProducts().isEmpty());
         Assertions.assertEquals(2, retrievedGroup.getProducts().size());
 
+    }
+
+    @Test
+    public void deleteGroupWithProductTest() {
+        //Given
+        Group group = new Group(1L , "Electronics", new ArrayList<>());
+        Group savedGroup = groupRepository.save(group);
+
+        Product product1 = new Product(1L, "LED TV", "Very big LED TV", new BigDecimal("6999"), group);
+        Product product2 = new Product(2L, "Soundbar", "Very laud soundbar", new BigDecimal("3999"), group);
+        productRepository.save(product1);
+        productRepository.save(product2);
+
+            // Sprawdzam czy produkty zostały przypisane do grupy
+            Optional<Group> foundGroup = groupRepository.findById(savedGroup.getId());
+            Group retrievedGroup = foundGroup.get();
+            System.out.println("Group ID: " + retrievedGroup.getId());
+            System.out.println("Products in group: " + retrievedGroup.getProducts());
+            System.out.println("Retrieved Products: " + retrievedGroup.getProducts().size());
+            retrievedGroup.getProducts().forEach(p -> System.out.println("Product: " + p.getName()));
+
+        //When & Then
+        Exception exception = Assertions.assertThrows(DataIntegrityViolationException.class, () -> {groupRepository.delete(savedGroup);});
+        System.out.println(exception.getMessage());
+        Assertions.assertTrue(foundGroup.isPresent());
     }
 }

--- a/src/test/java/com/kodilla/ecommercee/domain/GroupTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/GroupTestSuite.java
@@ -1,0 +1,142 @@
+package com.kodilla.ecommercee.domain;
+
+import com.kodilla.ecommercee.repository.GroupRepository;
+import com.kodilla.ecommercee.repository.ProductRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+public class GroupTestSuite {
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @AfterEach
+    public void cleanUp() {
+        groupRepository.deleteAll();
+        productRepository.deleteAll();
+    }
+
+    @Test
+    public void addGroupTest() {
+        //Given
+        Group group = new Group(null, "Electronics", new ArrayList<>());
+
+        //When
+        Group savedGroup = groupRepository.save(group);
+
+        //Then
+        Assertions.assertNotNull(savedGroup.getId());
+        Assertions.assertEquals("Electronics", savedGroup.getName());
+    }
+
+    @Test
+    public void findGroupByIdTest() {
+        //Given
+        Group group = new Group(null, "Electronics", new ArrayList<>());
+        Group savedGroup = groupRepository.save(group);
+
+        //When
+        Optional<Group> foundGroup = groupRepository.findById(savedGroup.getId());
+
+        //Then
+        Assertions.assertTrue(foundGroup.isPresent());
+        Assertions.assertEquals("Electronics", foundGroup.get().getName());
+    }
+
+    @Test
+    public void findAllGroupsTest() {
+        //Given
+        Group group1 = new Group(null , "Electronics", new ArrayList<>());
+        Group group2 = new Group(null, "Clothing", new ArrayList<>());
+        groupRepository.save(group1);
+        groupRepository.save(group2);
+
+        //When
+        List<Group> groups = (List<Group>) groupRepository.findAll();
+
+        //Then
+        Assertions.assertEquals(2, groups.size());
+    }
+
+    @Test
+    public void deleteGroupTest() {
+        //Given
+        Group group1 = new Group(null , "Electronics", new ArrayList<>());
+        Group group2 = new Group(null, "Clothing", new ArrayList<>());
+        groupRepository.save(group1);
+        groupRepository.save(group2);
+
+        //When
+        groupRepository.delete(group2);
+        List<Group> groups = (List<Group>) groupRepository.findAll();
+
+        //Then
+        Assertions.assertEquals(1, groups.size());
+    }
+
+    @Test
+    public void updateGroupTest() {
+        //Given
+        Group group = new Group(null , "Electronics", new ArrayList<>());
+        Group savedGroup = groupRepository.save(group);
+        Long id = savedGroup.getId();
+
+        //When
+        Optional<Group> foundGroup = groupRepository.findById(id);
+        foundGroup.ifPresent(g -> {
+            g.setName("Clothing");
+            groupRepository.save(g);
+        });
+        Optional<Group> updatedGroup = groupRepository.findById(id);
+
+        //Then
+        Assertions.assertTrue(updatedGroup.isPresent());
+        Assertions.assertEquals("Clothing", updatedGroup.get().getName());
+
+    }
+
+    @Test
+    public void findProductListAssignedToGroupTest() {
+        //Given
+        Group group = new Group(1L , "Electronics", new ArrayList<>());
+        groupRepository.save(group);
+
+        Product product1 = new Product(1L, "LED TV", "Very big LED TV", new BigDecimal("6999"), group);
+        Product product2 = new Product(2L, "Soundbar", "Very laud soundbar", new BigDecimal("3999"), group);
+        productRepository.save(product1);
+        productRepository.save(product2);
+
+            // Sprawdzam czy produkty zostały dodane do bazy
+            List<Product> allProducts = (List<Product>) productRepository.findAll();
+            System.out.println("Products in database: " + allProducts.size());
+
+        //When
+        Optional<Group> foundGroup = groupRepository.findById(group.getId());
+
+            // Sprawdzam czy produkty zostały przypisane do grupy
+            Group retrievedGroup = foundGroup.get();
+            System.out.println("Group ID: " + retrievedGroup.getId());
+            System.out.println("Products in group: " + retrievedGroup.getProducts());// Debugowanie
+            System.out.println("Retrieved Products: " + retrievedGroup.getProducts().size());
+            retrievedGroup.getProducts().forEach(p -> System.out.println("Product: " + p.getName()));
+
+        //Then
+        Assertions.assertTrue(foundGroup.isPresent());
+        Assertions.assertNotNull(retrievedGroup.getProducts());
+        Assertions.assertFalse(retrievedGroup.getProducts().isEmpty());
+        Assertions.assertEquals(2, retrievedGroup.getProducts().size());
+
+    }
+}


### PR DESCRIPTION
 Wcześniej tego nie przewidziałem a w trakcie testów wyszło że @Data wywołuje problem przy relacjach dwukierunkowych.
 @Data generuje m.in. toString() i to doprowadziło do błędnego zachowania:
 Group.toString() wywołuje Product.toString
 Product.toString() wywołuje Group.toString i tak w kółko, efekt StackOverFlowError.
 W encjach gdzie mamy relacje dwukierunkowe konieczna będzie zmiana na @Getter i @Setter.
 
 Dodatkowo dokonałem poprawek:
 Product - dodałem nazwę kolumny PRODUCT_ID bo brakowało
 Group - nazwy kolumn (GRUOP zmieniłem na GROUP - przez to relacja się nie budowała), FetchType z LAZY na EAGER
 Cart - refactoring klasy
 
 Przeniosłem też UserController i UserDto do odpowiednich pakietów. 